### PR TITLE
Remove autolabeler config

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,18 +1,9 @@
 categories:
-  - title: "🔧 Maintenance"
-    labels:
-      - "maintenance"
-
   - title: "⬆️ Dependencies"
     labels:
       - "dependencies"
       - "update-requirements-files"
       - "combined-pr"
-
-autolabeler:
-  - label: "maintenance"
-    branch:
-      - '/maint\/.+/'
 
 template: |
   ## What’s Changed


### PR DESCRIPTION
We don't want to actually label the issues in github with this...