### PR TITLE
Do not run release-drafer on pull requests

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -5,10 +5,6 @@ on:
     # branches to consider in the event; optional, defaults to all
     branches:
       - deploy/production
-  # pull_request event is required only for autolabeler
-  pull_request:
-    # Only following types are handled by the action, but one can default to all as well
-    types: [opened, reopened, synchronize]
 
 permissions:
   contents: read


### PR DESCRIPTION
This would keep creating new draft releases with the date that any PR is created or merged in.